### PR TITLE
Workaround for GameRegistry.makeItemStack bug in 1.7.10

### DIFF
--- a/src/main/java/ftb/lib/api/item/ItemStackSerializer.java
+++ b/src/main/java/ftb/lib/api/item/ItemStackSerializer.java
@@ -44,7 +44,9 @@ public class ItemStackSerializer
 			nbt = LMStringUtils.unsplitSpaceUntilEnd(3, s1);
 		}
 		
-		return GameRegistry.makeItemStack(itemID, size, dmg, nbt);
+		ItemStack newStack = GameRegistry.makeItemStack(itemID, dmg, size, nbt);
+		newStack.stackSize = size
+		return newStack;
 	}
 	
 	public static String toString(ItemStack is)


### PR DESCRIPTION
makeItemStack does not work properly on 1.7.10 due to the code being hardcoded for a stack size of 1.

Also, the parameter order was incorrect.
