### PR TITLE
Fix ForgeTeam.hasPermission()

### DIFF
--- a/src/main/java/com/feed_the_beast/ftbl/api_impl/ForgeTeam.java
+++ b/src/main/java/com/feed_the_beast/ftbl/api_impl/ForgeTeam.java
@@ -345,7 +345,12 @@ public final class ForgeTeam extends FinalIDObject implements IForgeTeam
     @Override
     public boolean hasPermission(UUID playerID, String permission)
     {
-        return playerID.equals(owner.getProfile().getId());
+        if (playerID.equals(owner.getProfile().getId()))
+            return true;
+        if (playerPermissions == null)
+            return false;
+        TShortCollection perms = playerPermissions.get(playerID);
+        return perms != null && perms.contains(Universe.INSTANCE.teamPlayerPermisssionIDs.generateID(permission));
 
     }
 


### PR DESCRIPTION
Originally, all it did was check whether or not the player was the owner, meaning that whether or not a player was invited to a team, they were not allowed to join. Now, it actually checks the permission database.