### PR TITLE
Integrate with JEI 4.14 bookmarks to avoid overlapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build
 # other
 eclipse
 run
+/classes

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,14 @@ compileJava {
 	sourceCompatibility = targetCompatibility = "1.8"
 }
 
+repositories {
+	maven { url "http://dvs1.progwml6.com/files/maven" }
+}
+
+dependencies {
+	deobfProvided "mezz.jei:jei_${mc_version}:${jei_version}:api"
+}
+
 minecraft {
 	version = "${mc_version}-${forge_version}"
 	runDir = "run"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,4 @@ curseforge_id=237167
 min_forge_version=14.23.4.2765
 forge_version=14.23.5.2784
 mappings_version=snapshot_20180814
+jei_version=4.14.0.230

--- a/src/main/java/com/feed_the_beast/ftblib/FTBLib.java
+++ b/src/main/java/com/feed_the_beast/ftblib/FTBLib.java
@@ -31,7 +31,7 @@ import java.util.Map;
 		name = FTBLib.MOD_NAME,
 		version = FTBLib.VERSION,
 		acceptableRemoteVersions = "*",
-		dependencies = "required-after:forge@[0.0.0.forge,)"
+		dependencies = "required-after:forge@[0.0.0.forge,);after:jei@[4.6.0,);"
 )
 public class FTBLib
 {

--- a/src/main/java/com/feed_the_beast/ftblib/client/FTBLibClientEventHandler.java
+++ b/src/main/java/com/feed_the_beast/ftblib/client/FTBLibClientEventHandler.java
@@ -44,6 +44,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
+import javax.annotation.Nullable;
+import java.awt.Rectangle;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -58,6 +60,7 @@ public class FTBLibClientEventHandler
 {
 	private static Temp currentNotification;
 	private static double sidebarButtonScale = 0D;
+	public static Rectangle lastDrawnArea = new Rectangle();
 
 	private static final IChatListener CHAT_LISTENER = (type, component) ->
 	{
@@ -236,10 +239,15 @@ public class FTBLibClientEventHandler
 	{
 		//sidebarButtonScale = 0D;
 
-		if (FTBLibClientConfig.action_buttons != EnumSidebarButtonPlacement.DISABLED && event.getGui() instanceof InventoryEffectRenderer && !SidebarButtonManager.INSTANCE.groups.isEmpty())
+		if (areButtonsVisible(event.getGui()))
 		{
 			event.getButtonList().add(new GuiButtonSidebarGroup((InventoryEffectRenderer) event.getGui()));
 		}
+	}
+
+	public static boolean areButtonsVisible(@Nullable GuiScreen gui)
+	{
+		return FTBLibClientConfig.action_buttons != EnumSidebarButtonPlacement.DISABLED && gui instanceof InventoryEffectRenderer && !SidebarButtonManager.INSTANCE.groups.isEmpty();
 	}
 
 	@SubscribeEvent
@@ -521,9 +529,10 @@ public class FTBLibClientEventHandler
 
 			GlStateManager.pushMatrix();
 
+			double scale = 1.0;
 			if (sidebarButtonScale < 1D)
 			{
-				double scale = Math.min(16D / MathUtils.lerp(width, 16D, sidebarButtonScale), 16D / MathUtils.lerp(height, 16D, sidebarButtonScale));
+				scale = Math.min(16D / MathUtils.lerp(width, 16D, sidebarButtonScale), 16D / MathUtils.lerp(height, 16D, sidebarButtonScale));
 				GlStateManager.scale(scale, scale, 1D);
 			}
 
@@ -599,6 +608,13 @@ public class FTBLibClientEventHandler
 			GlStateManager.popMatrix();
 			GlStateManager.popMatrix();
 			zLevel = 0F;
+
+			lastDrawnArea = new Rectangle(
+				(int) Math.ceil(x * scale),
+				(int) Math.ceil(y * scale),
+				(int) Math.ceil(width * scale),
+				(int) Math.ceil(height * scale)
+			);
 		}
 
 		@Override

--- a/src/main/java/com/feed_the_beast/ftblib/integration/JeiIntegration.java
+++ b/src/main/java/com/feed_the_beast/ftblib/integration/JeiIntegration.java
@@ -1,0 +1,47 @@
+package com.feed_the_beast.ftblib.integration;
+
+import javax.annotation.Nonnull;
+import java.awt.Rectangle;
+import java.util.Collection;
+import java.util.Collections;
+
+import com.feed_the_beast.ftblib.client.FTBLibClientEventHandler;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.IModRegistry;
+import mezz.jei.api.JEIPlugin;
+import mezz.jei.api.gui.IGlobalGuiHandler;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+
+/**
+ * @author mezz
+ */
+@JEIPlugin
+public class JeiIntegration implements IModPlugin
+{
+    @Override
+    public void register(IModRegistry registry)
+    {
+        try
+        {
+            registry.addGlobalGuiHandlers(new IGlobalGuiHandler()
+            {
+                @Override
+                @Nonnull
+                public Collection<Rectangle> getGuiExtraAreas()
+                {
+                    GuiScreen currentScreen = Minecraft.getMinecraft().currentScreen;
+                    if (FTBLibClientEventHandler.areButtonsVisible(currentScreen))
+                    {
+                        return Collections.singleton(FTBLibClientEventHandler.lastDrawnArea);
+                    }
+                    return Collections.emptySet();
+                }
+            });
+        }
+        catch (RuntimeException | LinkageError ignored)
+        {
+            // only JEI 4.14.0 or higher supports addGlobalGuiHandlers
+        }
+    }
+}


### PR DESCRIPTION
This will let FTBLib draw buttons and push JEI out of the way so they can work together nicely.

Tested these different button placements:
![2018-12-02_20 26 39](https://user-images.githubusercontent.com/916092/49353138-edba9c00-f670-11e8-905b-e5c0b4316451.png)
![2018-12-02_20 26 49](https://user-images.githubusercontent.com/916092/49353139-ee533280-f670-11e8-9fdc-d64416fc7e23.png)
![2018-12-02_20 26 51](https://user-images.githubusercontent.com/916092/49353140-ee533280-f670-11e8-9ed4-e14410a05cb6.png)

Note I found a FTBLib bug when you combine the inventory-side buttons option with the auto-shink option, the buttons act weirdly. JEI will still get out of the way though.