### PR TITLE
Fix Chinese input

### DIFF
--- a/src/main/java/com/feed_the_beast/ftblib/lib/gui/GuiWrapper.java
+++ b/src/main/java/com/feed_the_beast/ftblib/lib/gui/GuiWrapper.java
@@ -91,7 +91,7 @@ public class GuiWrapper extends GuiScreen implements IGuiWrapper
 	@Override
 	public void handleKeyboardInput() throws IOException
 	{
-		if (!Keyboard.getEventKeyState())
+		if (!(Keyboard.getEventKey() == 0 && Keyboard.getEventCharacter() >= ' ' || Keyboard.getEventKeyState()))
 		{
 			wrappedGui.keyReleased(Keyboard.getEventKey());
 		}


### PR DESCRIPTION
The boolean expression in the if statement for ```keyTyped``` is copied from ```net.minecraft.client.gui.GuiScreen.handleKeyboardInput```
<img width="605" alt="image" src="https://user-images.githubusercontent.com/17433503/57151652-0a1b5a00-6e04-11e9-8764-a26328c2339c.png">
Minecraft has applied such a modification since 1.9 so it should be safe.
This should allow Chinese input in ```com.feed_the_beast.ftblib.lib.gui.TextBox```.